### PR TITLE
fix:should append alterStatements outside the for loop

### DIFF
--- a/ddl/create.go
+++ b/ddl/create.go
@@ -651,11 +651,10 @@ func dbMigrateTableSQLite(migrateItem *TDbTableInitSql, db *sql.DB, msg proto.Me
 			migrateItem.DepTableSqlItemMap[depMsgName] = depMigrateItem
 			migrateItem.DepTableNames = append(migrateItem.DepTableNames, depMsgName)
 		}
+	}
 
-		if len(alterStatements) > 0 {
-			migrateItem.SqlStr = append(migrateItem.SqlStr, alterStatements...)
-		}
-
+	if len(alterStatements) > 0 {
+		migrateItem.SqlStr = append(migrateItem.SqlStr, alterStatements...)
 	}
 
 	pdbm, found := pdbutil.GetPDBM(msgDesc)

--- a/ddl/create.go
+++ b/ddl/create.go
@@ -491,11 +491,10 @@ func dbMigrateTablePostgres(migrateItem *TDbTableInitSql, db *sql.DB, msg proto.
 				migrateItem.DepTableNames = append(migrateItem.DepTableNames, depMsgName)
 			}
 		}
+	}
 
-		if len(alterStatements) > 0 {
-			migrateItem.SqlStr = append(migrateItem.SqlStr, alterStatements...)
-		}
-
+	if len(alterStatements) > 0 {
+		migrateItem.SqlStr = append(migrateItem.SqlStr, alterStatements...)
 	}
 
 	pdbm, found := pdbutil.GetPDBM(msgDesc)


### PR DESCRIPTION
在db.proto中间插入新的字段如`Avatar`后，生成的sqlStr切片中有多个相同的增加`Avatar`sql语句
![image](https://github.com/user-attachments/assets/43dc9562-8078-467e-b10b-ec5e5a7bb984)
